### PR TITLE
Added connection error handler.

### DIFF
--- a/KTVHTTPCache/Classes/KTVHCCommon/KTVHCError.h
+++ b/KTVHTTPCache/Classes/KTVHCCommon/KTVHCError.h
@@ -13,6 +13,7 @@
 KTVHTTPCACHE_EXTERN NSString * const KTVHCErrorDomainResponseUnavailable;
 KTVHTTPCACHE_EXTERN NSString * const KTVHCErrorDomainNotEnoughDiskSpace;
 
+KTVHTTPCACHE_EXTERN NSString * const KTVHCOperationFailingURLResponseErrorKey;
 
 typedef NS_ENUM(NSInteger, KTVHCErrorCode)
 {

--- a/KTVHTTPCache/Classes/KTVHCCommon/KTVHCError.m
+++ b/KTVHTTPCache/Classes/KTVHCCommon/KTVHCError.m
@@ -12,6 +12,7 @@
 NSString * const KTVHCErrorDomainResponseUnavailable    = @"KTVHCErrorDomainResponseUnavailable";       // player error
 NSString * const KTVHCErrorDomainNotEnoughDiskSpace     = @"KTVHCErrorDomainNotEnoughDiskSpace";        // player error
 
+NSString * const KTVHCOperationFailingURLResponseErrorKey = @"KTVHCOperationFailingURLResponseErrorKey";
 
 @implementation KTVHCError
 
@@ -38,7 +39,9 @@ NSString * const KTVHCErrorDomainNotEnoughDiskSpace     = @"KTVHCErrorDomainNotE
                                       userInfo:@{@"originalURL" : URLString,
                                                  @"requestHeader" : request.allHTTPHeaderFields,
                                                  @"responseURL" : response.URL.absoluteString,
-                                                 @"responseHeader" : response.allHeaderFields}];
+                                                 @"responseHeader" : response.allHeaderFields,
+                                                 KTVHCOperationFailingURLResponseErrorKey : response
+                                                 }];
     return error;
 }
 

--- a/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPConnection.h
+++ b/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPConnection.h
@@ -15,5 +15,6 @@
 
 + (NSString *)responsePingTokenString;
 
+- (void)handleErrorWithFailingResponse:(NSHTTPURLResponse *)response;
 
 @end

--- a/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPHeader.h
+++ b/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPHeader.h
@@ -14,6 +14,6 @@
 #import <CocoaHTTPServer/HTTPConnection.h>
 #import <CocoaHTTPServer/HTTPMessage.h>
 #import <CocoaHTTPServer/HTTPResponse.h>
-
+#import <CocoaHTTPServer/GCDAsyncSocket.h>
 
 #endif /* KTVHCHTTPHeader_h */

--- a/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPResponse.m
+++ b/KTVHTTPCache/Classes/KTVHCHTTPServer/KTVHCHTTPResponse.m
@@ -10,7 +10,7 @@
 #import "KTVHCHTTPConnection.h"
 #import "KTVHCDataStorage.h"
 #import "KTVHCLog.h"
-
+#import "KTVHCError.h"
 
 @interface KTVHCHTTPResponse () <KTVHCDataReaderDelegate>
 
@@ -162,7 +162,13 @@
     KTVHCLogHTTPResponse(@"failure, %ld, %@", error.code, self.dataRequest.URLString);
     
     [self.reader close];
-    [self.connection responseDidAbort:self];
+    
+    NSHTTPURLResponse *failingResponse = error.userInfo[KTVHCOperationFailingURLResponseErrorKey];
+    if (failingResponse) {
+        [self.connection handleErrorWithFailingResponse:failingResponse];
+    }else {
+        [self.connection responseDidAbort:self];
+    }
 }
 
 

--- a/Vendors/CocoaHTTPServer/CocoaHTTPServer.xcodeproj/project.pbxproj
+++ b/Vendors/CocoaHTTPServer/CocoaHTTPServer.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		9CA0A6511F3C04350034965E /* HTTPRedirectResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CA0A6161F3C04350034965E /* HTTPRedirectResponse.m */; };
 		9CA0A6521F3C04350034965E /* WebSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CA0A6171F3C04350034965E /* WebSocket.h */; };
 		9CA0A6531F3C04350034965E /* WebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CA0A6181F3C04350034965E /* WebSocket.m */; };
-		9CA0A6551F3C04350034965E /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CA0A61C1F3C04350034965E /* GCDAsyncSocket.h */; };
+		9CA0A6551F3C04350034965E /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CA0A61C1F3C04350034965E /* GCDAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9CA0A6561F3C04350034965E /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CA0A61D1F3C04350034965E /* GCDAsyncSocket.m */; };
 		9CA0A6581F3C04350034965E /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 9CA0A6201F3C04350034965E /* DDAbstractDatabaseLogger.h */; };
 		9CA0A6591F3C04350034965E /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CA0A6211F3C04350034965E /* DDAbstractDatabaseLogger.m */; };
@@ -297,6 +297,7 @@
 				9CA0A63B1F3C04350034965E /* HTTPMessage.h in Headers */,
 				9CA0A63D1F3C04350034965E /* HTTPResponse.h in Headers */,
 				9CA0A6381F3C04350034965E /* HTTPConnection.h in Headers */,
+				9CA0A6551F3C04350034965E /* GCDAsyncSocket.h in Headers */,
 				9CA0A6421F3C04350034965E /* MultipartMessageHeader.h in Headers */,
 				9CA0A64E1F3C04350034965E /* HTTPFileResponse.h in Headers */,
 				9CA0A6601F3C04350034965E /* DDTTYLogger.h in Headers */,
@@ -310,7 +311,6 @@
 				9CA0A6341F3C04350034965E /* DDRange.h in Headers */,
 				9CA0A6501F3C04350034965E /* HTTPRedirectResponse.h in Headers */,
 				9CA0A65C1F3C04350034965E /* DDFileLogger.h in Headers */,
-				9CA0A6551F3C04350034965E /* GCDAsyncSocket.h in Headers */,
 				9CA0A6301F3C04350034965E /* DDData.h in Headers */,
 				9CA0A65E1F3C04350034965E /* DDLog.h in Headers */,
 				9CA0A6321F3C04350034965E /* DDNumber.h in Headers */,

--- a/Vendors/CocoaHTTPServer/CocoaHTTPServer/CocoaHTTPServer.h
+++ b/Vendors/CocoaHTTPServer/CocoaHTTPServer/CocoaHTTPServer.h
@@ -15,3 +15,4 @@ FOUNDATION_EXPORT const unsigned char CocoaHTTPServerVersionString[];
 #import <CocoaHTTPServer/HTTPConnection.h>
 #import <CocoaHTTPServer/HTTPMessage.h>
 #import <CocoaHTTPServer/HTTPResponse.h>
+#import <CocoaHTTPServer/GCDAsyncSocket.h>


### PR DESCRIPTION
如果是网络请求错误，那么我们可以直接使用远程服务器所给的 response 来应答这次请求。

PS：这里还有一点问题，我在 CocoaHTTPServer 中导出了 GCDAsyncSocket.h，但这是不应该的。我建议使用 CocoaPods 的方式导入 CocoaHTTPServer。