### PR TITLE
Fix the issue that KTVHCDownload performs a lazy load for NSLock

### DIFF
--- a/KTVHTTPCache/Classes/KTVHCDownload/KTVHCDownload.m
+++ b/KTVHTTPCache/Classes/KTVHCDownload/KTVHCDownload.m
@@ -50,6 +50,7 @@ NSString * const KTVHCContentTypeBinaryOctetStream      = @"binary/octet-stream"
 {
     if (self = [super init]) {
         KTVHCLogAlloc(self);
+        self.coreLock = [[NSLock alloc] init];
         self.timeoutInterval = 30.0f;
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.errorDictionary = [NSMutableDictionary dictionary];
@@ -233,9 +234,6 @@ NSString * const KTVHCContentTypeBinaryOctetStream      = @"binary/octet-stream"
 
 - (void)lock
 {
-    if (!self.coreLock) {
-        self.coreLock = [[NSLock alloc] init];
-    }
     [self.coreLock lock];
 }
 


### PR DESCRIPTION
代码中这么用的地方还有很多，这个 PR 只改了 KTVHCDownload 。 #139 