### PR TITLE
Fix logical test when parsing WebSocket request.

### DIFF
--- a/KTVHTTPCache/CocoaHTTPServer/WebSocket.m
+++ b/KTVHTTPCache/CocoaHTTPServer/WebSocket.m
@@ -113,7 +113,7 @@ static inline NSUInteger WS_PAYLOAD_LENGTH(UInt8 frame)
 	if (!upgradeHeaderValue || !connectionHeaderValue) {
 		isWebSocket = NO;
 	}
-	else if (![upgradeHeaderValue caseInsensitiveCompare:@"WebSocket"] == NSOrderedSame) {
+	else if ([upgradeHeaderValue caseInsensitiveCompare:@"WebSocket"] != NSOrderedSame) {
 		isWebSocket = NO;
 	}
 	else if ([connectionHeaderValue rangeOfString:@"Upgrade" options:NSCaseInsensitiveSearch].location == NSNotFound) {


### PR DESCRIPTION
> WebSocket.m:116:11: warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]

This seems like a critical typo. `[NSString caseInsensitiveCompare:]` would never return null for a non-null string, thus the comparison would actually be reversed: Checking for `"WebSocket"` and then setting `isWebSocket` to false.