### PR TITLE
Fix NSUInteger on arm64 (and x86_64).

### DIFF
--- a/KTVHTTPCache/CocoaHTTPServer/Mime/MultipartFormDataParser.m
+++ b/KTVHTTPCache/CocoaHTTPServer/Mime/MultipartFormDataParser.m
@@ -29,7 +29,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN;
 - (int) findHeaderEnd:(NSData*) workingData fromOffset:(int) offset;
 - (int) findContentEnd:(NSData*) data fromOffset:(int) offset;
 
-- (int) numberOfBytesToLeavePendingWithData:(NSData*) data length:(NSUInteger) length encoding:(int) encoding;
+- (int) numberOfBytesToLeavePendingWithData:(NSData*) data length:(int) length encoding:(int) encoding;
 - (int) offsetTillNewlineSinceOffset:(int) offset inData:(NSData*) data;
 
 - (int) processPreamble:(NSData*) workingData;
@@ -244,7 +244,7 @@ static const int httpLogLevel = HTTP_LOG_LEVEL_WARN;
 			// this case, we didn't find the boundary, so the data is related to the current part.
 			// we leave the sizeToLeavePending amount of bytes to make sure we don't include 
 			// boundary part in processed data.
-			NSUInteger sizeToPass = workingData.length - offset - sizeToLeavePending;
+			int sizeToPass = (int)( workingData.length - offset - sizeToLeavePending );
 
 			// if we parse BASE64 encoded data, or Quoted-Printable data, we will make sure we don't break the format
 			int leaveTrailing = [self numberOfBytesToLeavePendingWithData:data length:sizeToPass encoding:currentEncoding];


### PR DESCRIPTION
> MultipartFormDataParser.m:420:73: warning: conflicting parameter types in implementation of 'numberOfBytesToLeavePendingWithData:length:encoding:': 'NSUInteger' (aka 'unsigned long') vs 'int' [-Wmismatched-parameter-types]

`NSUInteger`s are 64-bit on 64-bit platforms.